### PR TITLE
Add .gitignore for Python project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,82 @@ venv/
 __pycache__
 .vscode
 __pycache__/
+
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+.project
+.pydevproject
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+*.log


### PR DESCRIPTION
## Description
Added `.gitignore` file to exclude Python-generated files and sensitive data from version control.

## Changes
- Excludes `__pycache__/` and `.pyc` files
- Ignores `.env` and virtual environment directories
- Adds common IDE and OS files to ignore list

## Testing
- Verified that `.env` and `.pyc` files are not tracked
- Confirmed `git status` shows only intended files