### PR TITLE
Per-Agent Confidence Threshold Configuration #12

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -42,7 +42,8 @@ class Config:
 # Load configuration on import
 Config.load_config()
 
-# Provide sensible defaults if not supplied in config.yml
+# Per-agent confidence thresholds for GovernanceAgent (retriever, reasoner).
+# Override in config.yml under THRESHOLDS. See issue #12.
 if not hasattr(Config, "THRESHOLDS"):
     setattr(
         Config,

--- a/config.yml
+++ b/config.yml
@@ -10,6 +10,7 @@ EMBED_MODEL: all-MiniLM-L6-v2
 EMBED_DIM: 384
 AUTO_BUILD_FAISS: true
 CORPUS_DIR: data/corpus
+# Per-agent confidence thresholds (GovernanceAgent). See #12.
 THRESHOLDS:
   retriever: 0.2
   reasoner: 0.3


### PR DESCRIPTION
## Summary

Documents and clarifies the per-agent confidence threshold configuration. The behavior is already implemented: `config.yml` defines `THRESHOLDS` (retriever, reasoner) and `GovernanceAgent` reads and uses them.

Closes #12

## Acceptance criteria (already met)

- **Config file defines THRESHOLDS:** `config.yml` has `THRESHOLDS.retriever` and `THRESHOLDS.reasoner`; `app/config.py` provides defaults `{"retriever": 0.6, "reasoner": 0.7}` when missing.
- **GovernanceAgent reads and uses appropriate threshold:** Uses `reasoner_threshold` and `retriever_threshold` in `evaluate()` for approval decisions.

## Changes in this PR

- Add a short comment in `app/config.py` describing the per-agent thresholds and pointing to #12.
- Add a comment in `config.yml` for the `THRESHOLDS` section.

No behavior change; documentation only so the issue can be closed.

Made with [Cursor](https://cursor.com)